### PR TITLE
fix: add matchAll support for older versions of node

### DIFF
--- a/lib/codecs/UrlCodec.js
+++ b/lib/codecs/UrlCodec.js
@@ -2,6 +2,8 @@
  * Copyright (c) 2020 Digital Bazaar, Inc. All rights reserved.
  */
 import * as b58 from 'base58-universal';
+import semver from 'semver';
+import * as env from '../env';
 
 const urlHeaders = new Map();
 const urlEncoders = new Array();
@@ -68,8 +70,16 @@ const b58urlRegex =
   /(did:.*)?:z([1-9A-HJ-NP-Za-km-z]+)?#{0,1}z{0,1}([1-9A-HJ-NP-Za-km-z]+)?/g;
 export class Base58DidUrlCodec {
   encode(value) {
+
+    let matches;
     // break the base58 DID URL into segments
-    const matches = Array.from(value.matchAll(b58urlRegex));
+    if(env.nodejs && semver.lt(process.version, '12.0.0')) {
+      const matchAll = require('match-all');
+      matches = matchAll(value, b58urlRegex).toArray();
+    }
+    else {
+      matches = Array.from(value.matchAll(b58urlRegex));
+    }
     const match = matches[0];
 
     // encode the DID URL segments

--- a/lib/codecs/UrlCodec.js
+++ b/lib/codecs/UrlCodec.js
@@ -2,8 +2,7 @@
  * Copyright (c) 2020 Digital Bazaar, Inc. All rights reserved.
  */
 import * as b58 from 'base58-universal';
-import semver from 'semver';
-import * as env from '../env';
+import { matchAll } from '../util';
 
 const urlHeaders = new Map();
 const urlEncoders = new Array();
@@ -71,15 +70,8 @@ const b58urlRegex =
 export class Base58DidUrlCodec {
   encode(value) {
 
-    let matches;
     // break the base58 DID URL into segments
-    if(env.nodejs && semver.lt(process.version, '12.0.0')) {
-      const matchAll = require('match-all');
-      matches = matchAll(value, b58urlRegex).toArray();
-    }
-    else {
-      matches = Array.from(value.matchAll(b58urlRegex));
-    }
+    const matches = matchAll(value, b58urlRegex);
     const match = matches[0];
 
     // encode the DID URL segments

--- a/lib/codecs/UrlCodec.js
+++ b/lib/codecs/UrlCodec.js
@@ -2,7 +2,7 @@
  * Copyright (c) 2020 Digital Bazaar, Inc. All rights reserved.
  */
 import * as b58 from 'base58-universal';
-import { matchAll } from '../util';
+import {matchAll} from '../util';
 
 const urlHeaders = new Map();
 const urlEncoders = new Array();

--- a/lib/env.js
+++ b/lib/env.js
@@ -3,4 +3,4 @@
  */
 
 export const nodejs = (
-    typeof process !== 'undefined' && process.versions && process.versions.node);
+  typeof process !== 'undefined' && process.versions && process.versions.node);

--- a/lib/env.js
+++ b/lib/env.js
@@ -1,0 +1,6 @@
+/*!
+ * Copyright (c) 2018-2020 Digital Bazaar, Inc. All rights reserved.
+ */
+
+export const nodejs = (
+    typeof process !== 'undefined' && process.versions && process.versions.node);

--- a/lib/util-browser.js
+++ b/lib/util-browser.js
@@ -5,6 +5,6 @@ export function inspect(data, options) {
   return JSON.stringify(data, null, 2);
 }
 
-export function matchAll(string, regEx) { 
+export function matchAll(string, regEx) {
   return Array.from(string.matchAll(regEx));
-};
+}

--- a/lib/util-browser.js
+++ b/lib/util-browser.js
@@ -4,3 +4,7 @@
 export function inspect(data, options) {
   return JSON.stringify(data, null, 2);
 }
+
+export function matchAll(string, regEx) { 
+  return Array.from(string.matchAll(regEx));
+};

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,15 +1,14 @@
 // Node.js support
-import * as env from "./env";
+import * as env from './env';
 
 import semver from 'semver';
 export {inspect} from 'util';
 
 export function matchAll(string, regEx) {
-    if(env.nodejs && semver.lt(process.version, '12.0.0')) {
-        const matchAll = require('match-all')
-        return matchAll(string,regEx).toArray();
-    }
-    else {
-        return Array.from(string.matchAll(regEx));
-    }
+  if(env.nodejs && semver.lt(process.version, '12.0.0')) {
+    const matchAll = require('match-all');
+    return matchAll(string, regEx).toArray();
+  } else {
+    return Array.from(string.matchAll(regEx));
+  }
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,2 +1,15 @@
 // Node.js support
+import * as env from "./env";
+
+import semver from 'semver';
 export {inspect} from 'util';
+
+export function matchAll(string, regEx) {
+    if(env.nodejs && semver.lt(process.version, '12.0.0')) {
+        const matchAll = require('match-all')
+        return matchAll(string,regEx).toArray();
+    }
+    else {
+        return Array.from(string.matchAll(regEx));
+    }
+}

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "cbor": "^5.0.2",
     "esm": "^3.2.22",
     "js-base64": "^3.0.2",
+    "match-all": "^1.2.6",
+    "semver": "^7.3.4",
     "yargs": "^15.3.1"
   },
   "devDependencies": {

--- a/tests/test.spec.js
+++ b/tests/test.spec.js
@@ -178,5 +178,50 @@ describe('cborld', () => {
         '@context': 'https://w3id.org/age/v1', overAge: 21
       });
     });
+
+    it('should round trip sample DID document', async () => {
+      const SAMPLE_CONTEXT_URL = 'https://w3id.org/did/v0.11';
+      const SAMPLE_CONTEXT = {
+        '@context': {
+          '@protected': 'true',
+          id: '@id',
+          type: '@type'
+        }
+      };
+      const jsonldDocument = {
+        '@context': 'https://w3id.org/did/v0.11',
+        id: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+      };
+      const appContextMap = new Map();
+      appContextMap.set('https://w3id.org/did/v0.11', 0x8744);
+
+      const documentLoader = url => {
+        if(url === SAMPLE_CONTEXT_URL) {
+          return {
+            contextUrl: null,
+            document: SAMPLE_CONTEXT,
+            documentUrl: url
+          };
+        }
+        throw new Error('Invalid context url, cannot load!');
+      };
+
+      const encodedBytes = await encode({
+        jsonldDocument,
+        appContextMap,
+        documentLoader
+      });
+
+      const decodedDocument = await decode({
+        appContextMap,
+        cborldBytes: encodedBytes,
+        documentLoader
+      });
+
+      expect(decodedDocument).to.eql({
+        '@context': 'https://w3id.org/did/v0.11',
+        id: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+      });
+    });
   });
 });

--- a/tests/test.spec.js
+++ b/tests/test.spec.js
@@ -190,7 +190,7 @@ describe('cborld', () => {
       };
       const jsonldDocument = {
         '@context': 'https://w3id.org/did/v0.11',
-        id: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+        id: 'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH',
       };
       const appContextMap = new Map();
       appContextMap.set('https://w3id.org/did/v0.11', 0x8744);
@@ -220,7 +220,7 @@ describe('cborld', () => {
 
       expect(decodedDocument).to.eql({
         '@context': 'https://w3id.org/did/v0.11',
-        id: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+        id: 'did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH'
       });
     });
   });


### PR DESCRIPTION
String.matchAll() support was only added to node.js after version 12.0.0, [see here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll#browser_compatibility). This PR adds support for using the npm package [match-all](https://www.npmjs.com/package/match-all) when running the library in such an environment.