### PR TITLE
fix: xsd date codecs

### DIFF
--- a/lib/codec.js
+++ b/lib/codec.js
@@ -8,6 +8,7 @@ import {MultibaseCodec} from './codecs/MultibaseCodec.js';
 import {SimpleTypeCodec} from './codecs/SimpleTypeCodec.js';
 import {UrlCodec} from './codecs/UrlCodec.js';
 import {XsdDateTimeCodec} from './codecs/XsdDateTimeCodec.js';
+import {XsdDateCodec} from './codecs/XsdDateCodec.js';
 import {termCodecs} from './codecs/CodecMapCodec.js';
 
 /**
@@ -143,6 +144,9 @@ function _generateTermEncodingMap(context) {
         case 'http://www.w3.org/2001/XMLSchema#':
         case 'xsd:dateTime':
           codec = XsdDateTimeCodec;
+          break;
+        case 'xsd:date':
+          codec = XsdDateCodec;
           break;
         // FIXME: Expand all URLs so we don't have to also check against sec;
         // consider using jsonld.js to process context and get term definitions

--- a/lib/codecs/CodecMapCodec.js
+++ b/lib/codecs/CodecMapCodec.js
@@ -5,12 +5,14 @@
 import {MultibaseCodec} from './MultibaseCodec.js';
 import {UrlCodec} from './UrlCodec.js';
 import {XsdDateTimeCodec} from './XsdDateTimeCodec.js';
+import {XsdDateCodec} from './XsdDateCodec.js';
 
 const codecEncodeMap = new Map();
 const codecDecodeMap = new Map();
 _setEncodeDecodeMap(1, 'url');
 _setEncodeDecodeMap(2, 'multibase');
 _setEncodeDecodeMap(3, 'dateTime');
+_setEncodeDecodeMap(4, 'date');
 
 // all term codecs available to use when transforming term values
 export const termCodecs = new Map();
@@ -20,6 +22,8 @@ termCodecs.set('multibase', MultibaseCodec);
 termCodecs.set(2, MultibaseCodec);
 termCodecs.set('dateTime', XsdDateTimeCodec);
 termCodecs.set(3, XsdDateTimeCodec);
+termCodecs.set('date', XsdDateCodec);
+termCodecs.set(4, XsdDateCodec);
 
 export class CodecMapCodec {
   constructor() {

--- a/lib/codecs/XsdDateCodec.js
+++ b/lib/codecs/XsdDateCodec.js
@@ -1,7 +1,7 @@
 /*!
  * Copyright (c) 2020 Digital Bazaar, Inc. All rights reserved.
  */
-export class XsdDateTimeCodec {
+export class XsdDateCodec {
   constructor() {
   }
 
@@ -19,15 +19,17 @@ export class XsdDateTimeCodec {
     if(isNaN(parsedDate)) {
       throw new Error('Invalid input, could not parse value as date');
     }
-    if(this.value.indexOf('T') < 0) {
-      throw new Error('Invalid input, date missing time component');
+    if(this.value.indexOf('T') > 0) {
+      throw new Error('Invalid input, date includes time component \
+lost of precision expected');
     }
-    const encodedValue = Math.ceil(new Date(this.value).valueOf() / 1000);
+    const encodedValue = Math.ceil(parsedDate.valueOf() / 1000);
     return gen.pushAny(encodedValue);
   }
 
   decodeCBOR() {
     const decodedValue = new Date(this.value * 1000);
-    return decodedValue.toISOString().replace('.000Z', 'Z');
+    const dateString = decodedValue.toISOString();
+    return dateString.substring(0, dateString.indexOf('T'));
   }
 }

--- a/tests/MockEncoder.js
+++ b/tests/MockEncoder.js
@@ -1,0 +1,16 @@
+/*!
+* Copyright (c) 2020 Digital Bazaar, Inc. All rights reserved.
+*/
+
+/**
+ * Mock test utility for testing out custom codecs.
+ */
+export class MockEncoder {
+  constructor() {
+    this.result;
+  }
+
+  pushAny(value) {
+    this.result = value;
+  }
+}

--- a/tests/XsdDateCodec.spec.js
+++ b/tests/XsdDateCodec.spec.js
@@ -1,0 +1,70 @@
+/*!
+* Copyright (c) 2020 Digital Bazaar, Inc. All rights reserved.
+*/
+import {
+  expect
+} from 'chai';
+import {XsdDateCodec} from '../lib/codecs/XsdDateCodec';
+import {MockEncoder} from './MockEncoder';
+
+describe('XsdDateCodec', () => {
+  it('should roundtrip encode-decode successfully', async () => {
+    const input = '2020-07-14';
+    const mockEncoder = new MockEncoder();
+
+    const encoderCodec = new XsdDateCodec();
+    encoderCodec.set({value: input});
+    encoderCodec.encodeCBOR(mockEncoder);
+
+    const decoderCodec = new XsdDateCodec();
+    decoderCodec.set({value: mockEncoder.result});
+    const decodedResult = decoderCodec.decodeCBOR();
+
+    expect(input).equal(decodedResult);
+  });
+
+  it('should throw exception when input includes time component', async () => {
+    const input = '2020-07-14T19:23:24Z';
+    const mockEncoder = new MockEncoder();
+
+    const encoderCodec = new XsdDateCodec();
+    encoderCodec.set({value: input});
+    expect(() => encoderCodec.encodeCBOR(mockEncoder))
+      .to
+      .throw('Invalid input, date includes time \
+component lost of precision expected');
+  });
+
+  it('should throw exception when input is not a date string', async () => {
+    const input = 'bad';
+    const mockEncoder = new MockEncoder();
+
+    const encoderCodec = new XsdDateCodec();
+    encoderCodec.set({value: input});
+    expect(() => encoderCodec.encodeCBOR(mockEncoder))
+      .to
+      .throw('Invalid input, could not parse value as date');
+  });
+
+  it('should throw exception when input is an empty string', async () => {
+    const input = '';
+    const mockEncoder = new MockEncoder();
+
+    const encoderCodec = new XsdDateCodec();
+    encoderCodec.set({value: input});
+    expect(() => encoderCodec.encodeCBOR(mockEncoder))
+      .to
+      .throw('Invalid input, could not parse value as date');
+  });
+
+  it('should throw exception when input is not valid value type', async () => {
+    const input = true;
+    const mockEncoder = new MockEncoder();
+
+    const encoderCodec = new XsdDateCodec();
+    encoderCodec.set({value: input});
+    expect(() => encoderCodec.encodeCBOR(mockEncoder))
+      .to
+      .throw('Invalid input, expected value to be of type string');
+  });
+});

--- a/tests/XsdDateTimeCodec.spec.js
+++ b/tests/XsdDateTimeCodec.spec.js
@@ -1,0 +1,69 @@
+/*!
+* Copyright (c) 2020 Digital Bazaar, Inc. All rights reserved.
+*/
+import {
+  expect
+} from 'chai';
+import {XsdDateTimeCodec} from '../lib/codecs/XsdDateTimeCodec';
+import {MockEncoder} from './MockEncoder';
+
+describe('XsdDateTimeCodec', () => {
+  it('should roundtrip encode-decode successfully', async () => {
+    const input = '2020-07-14T19:23:24Z';
+    const mockEncoder = new MockEncoder();
+
+    const encoderCodec = new XsdDateTimeCodec();
+    encoderCodec.set({value: input});
+    encoderCodec.encodeCBOR(mockEncoder);
+
+    const decoderCodec = new XsdDateTimeCodec();
+    decoderCodec.set({value: mockEncoder.result});
+    const decodedResult = decoderCodec.decodeCBOR();
+
+    expect(input).equal(decodedResult);
+  });
+
+  it('should throw exception when input missing time component', async () => {
+    const input = '2020-07-14';
+    const mockEncoder = new MockEncoder();
+
+    const encoderCodec = new XsdDateTimeCodec();
+    encoderCodec.set({value: input});
+    expect(() => encoderCodec.encodeCBOR(mockEncoder))
+      .to
+      .throw('Invalid input, date missing time component');
+  });
+
+  it('should throw exception when input is not a date string', async () => {
+    const input = 'bad';
+    const mockEncoder = new MockEncoder();
+
+    const encoderCodec = new XsdDateTimeCodec();
+    encoderCodec.set({value: input});
+    expect(() => encoderCodec.encodeCBOR(mockEncoder))
+      .to
+      .throw('Invalid input, could not parse value as date');
+  });
+
+  it('should throw exception when input is an empty string', async () => {
+    const input = '';
+    const mockEncoder = new MockEncoder();
+
+    const encoderCodec = new XsdDateTimeCodec();
+    encoderCodec.set({value: input});
+    expect(() => encoderCodec.encodeCBOR(mockEncoder))
+      .to
+      .throw('Invalid input, could not parse value as date');
+  });
+
+  it('should throw exception when input is not valid value type', async () => {
+    const input = true;
+    const mockEncoder = new MockEncoder();
+
+    const encoderCodec = new XsdDateTimeCodec();
+    encoderCodec.set({value: input});
+    expect(() => encoderCodec.encodeCBOR(mockEncoder))
+      .to
+      .throw('Invalid input, expected value to be of type string');
+  });
+});


### PR DESCRIPTION
Resolves an issue that was occurring when the XsdDateTimeCodec was encoding a string that was missing a time component resulting in a date string being returned on decode that featured a zero'd out time component hence not making the encode-decode lossless.

This PR adds another codec for handling values of type date separately and  test cases for both codecs.