### PR TITLE
Bundle with Babel, remove esm module loader

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: ["@babel/plugin-transform-modules-commonjs"],
+};

--- a/index.js
+++ b/index.js
@@ -1,8 +1,0 @@
-/*!
- * Copyright (c) 2020 Digital Bazaar, Inc. All rights reserved.
- */
-'use strict';
-
-// translate `main.js` to CommonJS
-require = require('esm')(module);
-module.exports = require('./main.js');

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,7 @@
+/*!
+ * Copyright (c) 2020 Digital Bazaar, Inc. All rights reserved.
+ */
+"use strict";
+
+export { decode } from "./decode.js";
+export { encode } from "./encode.js";

--- a/main.js
+++ b/main.js
@@ -1,5 +1,0 @@
-/*!
- * Copyright (c) 2020-2021 Digital Bazaar, Inc. All rights reserved.
- */
-export {decode} from './lib/decode.js';
-export {encode} from './lib/encode.js';

--- a/package.json
+++ b/package.json
@@ -22,16 +22,18 @@
     "linked data",
     "compression"
   ],
-  "main": "index.js",
-  "module": "main.js",
+  "main": "dist/index.js",
+  "module": "lib/index.js",
   "browser": {
-    "index.js": "main.js",
+    "index.js": "./lib/index.js",
     "./lib/util.js": "./lib/util-browser.js"
   },
   "engines": {
     "node": ">=12"
   },
   "scripts": {
+    "prepublish": "npm run build",
+    "build": "babel lib --out-dir dist",
     "test": "npm run test-node",
     "test-node": "cross-env NODE_ENV=test mocha -r esm --preserve-symlinks -t 30000 -A -R ${REPORTER:-spec} tests/*.spec.js",
     "test-karma": "karma start karma.conf.js",
@@ -42,18 +44,18 @@
     "lint": "eslint ."
   },
   "files": [
-    "index.js",
     "lib",
-    "main.js"
+    "dist"
   ],
   "dependencies": {
     "base58-universal": "^1.0.0",
     "cborg": "^1.2.0",
-    "esm": "^3.2.22",
     "js-base64": "^3.6.0",
     "uuid": "^8.3.1"
   },
   "devDependencies": {
+    "@babel/cli": "^7.14.5",
+    "@babel/plugin-transform-modules-commonjs": "^7.14.5",
     "benchmark": "^2.1.4",
     "chai": "^4.3.0",
     "chai-bytes": "^0.1.2",
@@ -70,8 +72,7 @@
     "karma-webpack": "^4.0.2",
     "mocha": "^8.3.0",
     "mocha-lcov-reporter": "^1.3.0",
-    "nyc": "^15.0.0",
-    "webpack": "^4.46.0"
+    "nyc": "^15.0.0"
   },
   "nyc": {
     "exclude": [


### PR DESCRIPTION
**Description**

Remove:
- ECMAScript module loader.

Changed:
- Switch to Babel to build bundle with minimal configs

**Motivation**

Jest seems to have compatibility issues with modules generated by the [esm module loader](https://www.npmjs.com/package/esm), which causes the `cborld` library to produce unexpected results, and very high memory and CPU consumption while running each test case, as well as rapidly slowing down the execution (it happened to take almost 20 seconds to run a simple test case).

---

To illustrate the problem, I have created a small repro repo with my assumptions for the root cause:
https://github.com/zhenwenc/cbor-issue/blob/main/src/__tests__/cborld-encode.spec.ts

You can view the failure test result in this pipeline:
https://github.com/zhenwenc/cbor-issue/runs/2780071449?check_suite_focus=true

My suspicion is that the subclass instances of `CborldEncoder` aren't been encoded by the defined `encode` function due to the `instanceof` check returns incorrect result. For example:

     const encoder = ContextEncoder.createEncoder({ value, transformer: this });
     expect(encoder instanceof CborldEncoder).toBe(true); // but returns false

Therefore, the `encoder` token above will be unexpectedly processed by the `cborg` default encoders.

 This is likely related to the compatibility issue of CJS generation from ESM
 with Jest which seems to have its own `require` implementation.

---

Therefore, I suggest would you consider transpiling the source code with a bundler before publishing the package? This PR contains the minimal configuration for Babel.

Thanks!