### PR TITLE
appContextMap fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 - Use `appContextMap` in `CryptosuiteEncoder`.
+- Ensure custom `appContextMap` is used first before registered table of term
+  codecs in cryptosuite codecs.
 
 ## 6.0.2 - 2023-11-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @digitalbazaar/cborld ChangeLog
 
+## 6.0.3 - 2023-xx-xx
+
+### Fixed
+- Use `appContextMap` in `CryptosuiteEncoder`.
+
 ## 6.0.2 - 2023-11-29
 
 ### Fixed

--- a/lib/codecs/CryptosuiteDecoder.js
+++ b/lib/codecs/CryptosuiteDecoder.js
@@ -18,7 +18,7 @@ export class CryptosuiteDecoder extends CborldDecoder {
     }
 
     // handle compressed cryptosuite string
-    const str = ID_TO_STRING.get(value) || this.reverseAppContextMap.get(value);
+    const str = this.reverseAppContextMap.get(value) || ID_TO_STRING.get(value);
     if(str === undefined) {
       throw new CborldError(
         'ERR_UNDEFINED_COMPRESSED_CRYPTOSUITE_STRING',

--- a/lib/codecs/CryptosuiteEncoder.js
+++ b/lib/codecs/CryptosuiteEncoder.js
@@ -14,7 +14,7 @@ export class CryptosuiteEncoder extends CborldEncoder {
 
   encode() {
     const {value} = this;
-    const id = STRING_TO_ID.get(value) || this.appContextMap.get(value);
+    const id = this.appContextMap.get(value) || STRING_TO_ID.get(value);
     if(id === undefined) {
       return new Token(Type.string, value);
     }

--- a/lib/codecs/CryptosuiteEncoder.js
+++ b/lib/codecs/CryptosuiteEncoder.js
@@ -6,9 +6,10 @@ import {CborldEncoder} from './CborldEncoder.js';
 import {STRING_TO_ID} from './registeredTermCodecs.js';
 
 export class CryptosuiteEncoder extends CborldEncoder {
-  constructor({value} = {}) {
+  constructor({value, appContextMap} = {}) {
     super();
     this.value = value;
+    this.appContextMap = appContextMap;
   }
 
   encode() {


### PR DESCRIPTION
- Missed destructuring appContextMap in CryptosuiteEncoder.
- It looks like the cryptosuite codecs should do what the context codecs are doing and check the custom map first.