### PR TITLE
Add support for compressing arbitrary URLs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @digitalbazaar/cborld ChangeLog
 
+## 6.1.0 - 2023-xx-xx
+
+### Added
+- Add support for compressing arbitrary URLs. Any id which is in the
+  `appContextMap` will be compressed as a single number before using other URL
+  codecs.
+
 ## 6.0.3 - 2023-12-19
 
 ### Fixed

--- a/lib/Decompressor.js
+++ b/lib/Decompressor.js
@@ -202,7 +202,7 @@ export class Decompressor extends Transformer {
   }
 
   _transformObjectId({obj, termInfo, value}) {
-    const decoder = UriDecoder.createDecoder({value});
+    const decoder = UriDecoder.createDecoder({value, transformer: this});
     obj[termInfo.term] = decoder ? decoder.decode({value}) : value;
   }
 

--- a/lib/codecs/AppUrlDecoder.js
+++ b/lib/codecs/AppUrlDecoder.js
@@ -1,0 +1,36 @@
+/*!
+ * Copyright (c) 2021-2023 Digital Bazaar, Inc. All rights reserved.
+ */
+import {CborldDecoder} from './CborldDecoder.js';
+import {CborldError} from '../CborldError.js';
+
+const ID = 1026;
+
+export class AppUrlDecoder extends CborldDecoder {
+  constructor({reverseAppContextMap} = {}) {
+    super();
+    this.reverseAppContextMap = reverseAppContextMap;
+  }
+
+  decode({value} = {}) {
+    // handle compressed app URL
+    const url = this.reverseAppContextMap.get(value[1]);
+    if(url === undefined) {
+      throw new CborldError(
+        'ERR_UNDEFINED_COMPRESSED_APP_URL',
+        `Undefined compressed app URL "${value}".`);
+    }
+    return url;
+  }
+
+  static createDecoder({value, transformer} = {}) {
+    if(!(Array.isArray(value) && value.length === 2)) {
+      return false;
+    }
+    if(!(value[0] === ID)) {
+      return false;
+    }
+    const {reverseAppContextMap} = transformer;
+    return new AppUrlDecoder({reverseAppContextMap});
+  }
+}

--- a/lib/codecs/AppUrlEncoder.js
+++ b/lib/codecs/AppUrlEncoder.js
@@ -1,0 +1,35 @@
+/*!
+ * Copyright (c) 2021-2023 Digital Bazaar, Inc. All rights reserved.
+ */
+import {Token, Type} from 'cborg';
+import {CborldEncoder} from './CborldEncoder.js';
+
+const ID = 1026;
+
+export class AppUrlEncoder extends CborldEncoder {
+  constructor({value, appContextMap} = {}) {
+    super();
+    this.value = value;
+    this.appContextMap = appContextMap;
+  }
+
+  encode() {
+    const {value} = this;
+    // FIXME: handle errors (shouldn't happen if called correctly)
+    const id = this.appContextMap.get(value);
+    const entries = [
+      new Token(Type.uint, ID),
+      new Token(Type.uint, id)
+    ];
+    return [new Token(Type.array, entries.length), entries];
+  }
+
+  static createEncoder({value, transformer} = {}) {
+    // FIXME: needed?
+    if(typeof value !== 'string') {
+      return false;
+    }
+    const {appContextMap} = transformer;
+    return new AppUrlEncoder({value, appContextMap});
+  }
+}

--- a/lib/codecs/UriDecoder.js
+++ b/lib/codecs/UriDecoder.js
@@ -1,6 +1,7 @@
 /*!
  * Copyright (c) 2021-2023 Digital Bazaar, Inc. All rights reserved.
  */
+import {AppUrlDecoder} from './AppUrlDecoder.js';
 import {Base58DidUrlDecoder} from './Base58DidUrlDecoder.js';
 import {CborldDecoder} from './CborldDecoder.js';
 import {HttpUrlDecoder} from './HttpUrlDecoder.js';
@@ -11,16 +12,18 @@ const SCHEME_ID_TO_DECODER = new Map([
   [2, HttpUrlDecoder],
   [3, UuidUrnDecoder],
   [1024, Base58DidUrlDecoder],
-  [1025, Base58DidUrlDecoder]
+  [1025, Base58DidUrlDecoder],
+  // FIXME: encdeds as 3 bytes, may want to use a lower id
+  [1026, AppUrlDecoder]
 ]);
 
 export class UriDecoder extends CborldDecoder {
-  static createDecoder({value} = {}) {
+  static createDecoder({value, transformer} = {}) {
     if(!(Array.isArray(value) || value.length > 1)) {
       return false;
     }
 
     const DecoderClass = SCHEME_ID_TO_DECODER.get(value[0]);
-    return DecoderClass && DecoderClass.createDecoder({value});
+    return DecoderClass && DecoderClass.createDecoder({value, transformer});
   }
 }

--- a/lib/codecs/UriEncoder.js
+++ b/lib/codecs/UriEncoder.js
@@ -1,6 +1,7 @@
 /*!
  * Copyright (c) 2021-2023 Digital Bazaar, Inc. All rights reserved.
  */
+import {AppUrlEncoder} from './AppUrlEncoder.js';
 import {Base58DidUrlEncoder} from './Base58DidUrlEncoder.js';
 import {CborldEncoder} from './CborldEncoder.js';
 import {HttpUrlEncoder} from './HttpUrlEncoder.js';
@@ -15,9 +16,14 @@ const SCHEME_TO_ENCODER = new Map([
 ]);
 
 export class UriEncoder extends CborldEncoder {
-  static createEncoder({value} = {}) {
+  static createEncoder({value, transformer} = {}) {
     if(typeof value !== 'string') {
       return false;
+    }
+
+    const {appContextMap} = transformer;
+    if(appContextMap.has(value)) {
+      return AppUrlEncoder.createEncoder({value, transformer});
     }
 
     // get full colon-delimited prefix


### PR DESCRIPTION
Add support for compressing arbitrary URLs. Any id which is in the `appContextMap` will be compressed as a single number before using other URL codecs.

- Need feedback if this is a good feature and approach.
- The `appContextMap` naming is being overridden here and elsewhere.  This feature could change and use another map.
- The sub-codec is value is important.  `1026` is encoded as 3 bytes.  A low value would be 1 or 2 bytes.  If lots of URLs get encoded this would add up.
- This was modified from other codecs, it may be able to be cleaned up if not handling fallback cases.
- Needs tests.