### PR TITLE
Use vocab term codec for URIs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 7.0.0 - 2024-mm-dd
 
+### Added
+- **BREAKING**: Add support for compressing RFC 2397 data URLs. Base64 encoded
+  data is compressed as binary.
+
 ### Changed
 - **BREAKING**: Encode cryptosuite strings using a separate registry (specific
   to cryptosuites) to further reduce their encoded size (instead of using

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
   to cryptosuites) to further reduce their encoded size (instead of using
   the global table). This approach is incompatible with previous encodings
   that used the global table.
+- **BREAKING**: Encode all URIs using the vocab term codec. This allows
+  arbitrary URIs to be encoded with the same small integers as other terms.
+  The mapping in a context needs to use a redundant form: `{"URI":"URI"}`. This
+  technique assume a use case where the CBOR-LD size has high priority over
+  context size.
 
 ## 6.0.3 - 2023-12-19
 

--- a/lib/codecs/DataUrlDecoder.js
+++ b/lib/codecs/DataUrlDecoder.js
@@ -1,0 +1,30 @@
+/*!
+ * Copyright (c) 2024 Digital Bazaar, Inc. All rights reserved.
+ */
+import {Base64} from 'js-base64';
+import {CborldDecoder} from './CborldDecoder.js';
+
+export class DataUrlDecoder extends CborldDecoder {
+  constructor() {
+    super();
+  }
+
+  decode({value} = {}) {
+    if(value.length === 3) {
+      return `data:${value[1]};base64,${Base64.fromUint8Array(value[2])}`;
+    } else {
+      return `data:${value[1]}`;
+    }
+  }
+
+  static createDecoder({value} = {}) {
+    if(value.length === 3 && typeof value[1] === 'string' &&
+      value[2] instanceof Uint8Array) {
+      return new DataUrlDecoder({value});
+    }
+    if(value.length === 2 && typeof value[1] === 'string') {
+      return new DataUrlDecoder({value});
+    }
+    return false;
+  }
+}

--- a/lib/codecs/DataUrlEncoder.js
+++ b/lib/codecs/DataUrlEncoder.js
@@ -1,0 +1,80 @@
+/*!
+ * Copyright (c) 2024 Digital Bazaar, Inc. All rights reserved.
+ */
+import {Token, Type} from 'cborg';
+import {Base64} from 'js-base64';
+import {CborldEncoder} from './CborldEncoder.js';
+
+// data URL codec for base64 data
+// https://www.rfc-editor.org/rfc/rfc2397
+// https://fetch.spec.whatwg.org/#data-urls
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs
+// data:[<mediatype>][;base64],<data>
+
+// This codec must be able to round-trip the data. The parsing is minimal and
+// designed to only binary encode well formed base64 data that can be decoded
+// to the same input. The mediatype (with optional parameters) is stored as-is,
+// with the exception of ";base64" if correct base64 encoding is detected. In
+// the case of a non-base64 data URI, all but the "data:" prefix is encoded as
+// a string.
+
+// base64 encoding: [string, data]
+// non-base64 encoding: [string]
+
+// TODO: An optimization could use a registry of well known base mediatypes
+// (ie, image/png, text/plain, etc).
+
+// base64 data uri regex
+// when using this, use round trip code to ensure decoder will work
+const DATA_BASE64_REGEX = /^data:(?<mediatype>.*);base64,(?<data>.*)$/;
+
+export class DataUrlEncoder extends CborldEncoder {
+  constructor({value, base64} = {}) {
+    super();
+    this.value = value;
+    this.base64 = base64;
+  }
+
+  encode() {
+    const {value, base64} = this;
+
+    const entries = [
+      new Token(Type.uint, 4),
+    ];
+
+    if(base64) {
+      // base64 mode
+      // [string, bytes]
+      const parsed = DATA_BASE64_REGEX.exec(value);
+      entries.push(
+        new Token(Type.string, parsed.groups.mediatype));
+      entries.push(
+        new Token(Type.bytes, Base64.toUint8Array(parsed.groups.data)));
+    } else {
+      // non-base64 mode
+      // [string]
+      entries.push(
+        new Token(Type.string, value.slice('data:'.length)));
+    }
+
+    return [new Token(Type.array, entries.length), entries];
+  }
+
+  static createEncoder({value} = {}) {
+    // quick check
+    if(!value.startsWith('data:')) {
+      return;
+    }
+    // attempt to parse as a base64
+    const parsed = DATA_BASE64_REGEX.exec(value);
+    if(parsed) {
+      // check to ensure data can be restored
+      // this avoids issues with variations in encoding
+      const data = parsed.groups.data;
+      if(data === Base64.fromUint8Array(Base64.toUint8Array(data))) {
+        return new DataUrlEncoder({value, base64: true});
+      }
+    }
+    return new DataUrlEncoder({value, base64: false});
+  }
+}

--- a/lib/codecs/DataUrlEncoder.js
+++ b/lib/codecs/DataUrlEncoder.js
@@ -12,7 +12,7 @@ import {CborldEncoder} from './CborldEncoder.js';
 // data:[<mediatype>][;base64],<data>
 
 // This codec must be able to round-trip the data. The parsing is minimal and
-// designed to only binary encode well formed base64 data that can be decoded
+// designed to only binary encode well-formed base64 data that can be decoded
 // to the same input. The mediatype (with optional parameters) is stored as-is,
 // with the exception of ";base64" if correct base64 encoding is detected. In
 // the case of a non-base64 data URI, all but the "data:" prefix is encoded as
@@ -21,7 +21,7 @@ import {CborldEncoder} from './CborldEncoder.js';
 // base64 encoding: [string, data]
 // non-base64 encoding: [string]
 
-// TODO: An optimization could use a registry of well known base mediatypes
+// TODO: An optimization could use a registry of well-known base mediatypes
 // (ie, image/png, text/plain, etc).
 
 // base64 data uri regex

--- a/lib/codecs/DataUrlEncoder.js
+++ b/lib/codecs/DataUrlEncoder.js
@@ -5,24 +5,29 @@ import {Token, Type} from 'cborg';
 import {Base64} from 'js-base64';
 import {CborldEncoder} from './CborldEncoder.js';
 
-// data URL codec for base64 data
-// https://www.rfc-editor.org/rfc/rfc2397
-// https://fetch.spec.whatwg.org/#data-urls
-// https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs
-// data:[<mediatype>][;base64],<data>
+/*
+Data URL codec for base64 data.
 
-// This codec must be able to round-trip the data. The parsing is minimal and
-// designed to only binary encode well-formed base64 data that can be decoded
-// to the same input. The mediatype (with optional parameters) is stored as-is,
-// with the exception of ";base64" if correct base64 encoding is detected. In
-// the case of a non-base64 data URI, all but the "data:" prefix is encoded as
-// a string.
+References:
+https://www.rfc-editor.org/rfc/rfc2397
+https://fetch.spec.whatwg.org/#data-urls
+https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs
 
-// base64 encoding: [string, data]
-// non-base64 encoding: [string]
+Data URL format:
+data:[<mediatype>][;base64],<data>
 
-// TODO: An optimization could use a registry of well-known base mediatypes
-// (ie, image/png, text/plain, etc).
+This codec must be able to round-trip the data. The parsing is minimal and
+designed to only binary encode well-formed base64 data that can be decoded to
+the same input. The mediatype (with optional parameters) is stored as-is, with
+the exception of ";base64" if correct base64 encoding is detected. In the case
+of a non-base64 data URI, all but the "data:" prefix is encoded as a string.
+
+base64 encoding: [string, data]
+non-base64 encoding: [string]
+
+TODO: An optimization could use a registry of well-known base mediatypes (ie,
+image/png, text/plain, etc).
+*/
 
 // base64 data uri regex
 // when using this, use round trip code to ensure decoder will work

--- a/lib/codecs/UriDecoder.js
+++ b/lib/codecs/UriDecoder.js
@@ -3,6 +3,7 @@
  */
 import {Base58DidUrlDecoder} from './Base58DidUrlDecoder.js';
 import {CborldDecoder} from './CborldDecoder.js';
+import {DataUrlDecoder} from './DataUrlDecoder.js';
 import {HttpUrlDecoder} from './HttpUrlDecoder.js';
 import {UuidUrnDecoder} from './UuidUrnDecoder.js';
 import {VocabTermDecoder} from './VocabTermDecoder.js';
@@ -11,6 +12,7 @@ const SCHEME_ID_TO_DECODER = new Map([
   [1, HttpUrlDecoder],
   [2, HttpUrlDecoder],
   [3, UuidUrnDecoder],
+  [4, DataUrlDecoder],
   [1024, Base58DidUrlDecoder],
   [1025, Base58DidUrlDecoder]
 ]);

--- a/lib/codecs/UriDecoder.js
+++ b/lib/codecs/UriDecoder.js
@@ -5,6 +5,7 @@ import {Base58DidUrlDecoder} from './Base58DidUrlDecoder.js';
 import {CborldDecoder} from './CborldDecoder.js';
 import {HttpUrlDecoder} from './HttpUrlDecoder.js';
 import {UuidUrnDecoder} from './UuidUrnDecoder.js';
+import {VocabTermDecoder} from './VocabTermDecoder.js';
 
 const SCHEME_ID_TO_DECODER = new Map([
   [1, HttpUrlDecoder],
@@ -15,8 +16,11 @@ const SCHEME_ID_TO_DECODER = new Map([
 ]);
 
 export class UriDecoder extends CborldDecoder {
-  static createDecoder({value} = {}) {
+  static createDecoder({value, transformer} = {}) {
     if(!(Array.isArray(value) || value.length > 1)) {
+      if(transformer.idToTerm.has(value)) {
+        return VocabTermDecoder.createDecoder({value, transformer});
+      }
       return false;
     }
 

--- a/lib/codecs/UriEncoder.js
+++ b/lib/codecs/UriEncoder.js
@@ -29,7 +29,7 @@ export class UriEncoder extends CborldEncoder {
       return false;
     }
 
-    // check vocab term map
+    // first check vocab term map to maximize URL compression
     if(transformer.termToId.has(value)) {
       return VocabTermEncoder.createEncoder({value, transformer});
     }

--- a/lib/codecs/UriEncoder.js
+++ b/lib/codecs/UriEncoder.js
@@ -3,6 +3,7 @@
  */
 import {Base58DidUrlEncoder} from './Base58DidUrlEncoder.js';
 import {CborldEncoder} from './CborldEncoder.js';
+import {DataUrlEncoder} from './DataUrlEncoder.js';
 import {HttpUrlEncoder} from './HttpUrlEncoder.js';
 import {UuidUrnEncoder} from './UuidUrnEncoder.js';
 import {VocabTermEncoder} from './VocabTermEncoder.js';
@@ -13,12 +14,14 @@ import {VocabTermEncoder} from './VocabTermEncoder.js';
 // `1` http
 // `2` https
 // `3` urn:uuid
+// `4` data (RFC 2397)
 // `1024` did:v1:nym
 // `1025` did:key
 const SCHEME_TO_ENCODER = new Map([
   ['http', HttpUrlEncoder],
   ['https', HttpUrlEncoder],
   ['urn:uuid', UuidUrnEncoder],
+  ['data', DataUrlEncoder],
   ['did:v1:nym', Base58DidUrlEncoder],
   ['did:key', Base58DidUrlEncoder]
 ]);

--- a/lib/codecs/UriEncoder.js
+++ b/lib/codecs/UriEncoder.js
@@ -5,6 +5,7 @@ import {Base58DidUrlEncoder} from './Base58DidUrlEncoder.js';
 import {CborldEncoder} from './CborldEncoder.js';
 import {HttpUrlEncoder} from './HttpUrlEncoder.js';
 import {UuidUrnEncoder} from './UuidUrnEncoder.js';
+import {VocabTermEncoder} from './VocabTermEncoder.js';
 
 // an encoded URL is an array with the first element being an integer that
 // signals which encoder was used:
@@ -23,11 +24,17 @@ const SCHEME_TO_ENCODER = new Map([
 ]);
 
 export class UriEncoder extends CborldEncoder {
-  static createEncoder({value} = {}) {
+  static createEncoder({value, transformer} = {}) {
     if(typeof value !== 'string') {
       return false;
     }
 
+    // check vocab term map
+    if(transformer.termToId.has(value)) {
+      return VocabTermEncoder.createEncoder({value, transformer});
+    }
+
+    // check URI prefix codecs
     // get full colon-delimited prefix
     let scheme;
     try {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "coverage": "cross-env NODE_ENV=test c8 npm run test-node",
     "coverage-ci": "cross-env NODE_ENV=test c8 --reporter=lcovonly --reporter=text-summary --reporter=text npm run test-node",
     "coverage-report": "c8 report",
-    "lint": "eslint ."
+    "lint": "eslint --ext .cjs,.js ."
   },
   "dependencies": {
     "base58-universal": "^2.0.0",


### PR DESCRIPTION
Encode all URIs using the vocab term codec. This allows arbitrary URIs to be encoded with the same small integers as other terms. The mapping in a context needs to use a redundant form: `{"URI":"URI"}`. This technique assume a use case where the CBOR-LD size has high priority over context size.

I'm not sure if there are edge cases with the technique here.  (Need a better test suite.)  The URI codec is making assumptions when it sees a "value: int" structure that the int is a term id.  Would it ever be something else there?

I'm assuming this is breaking as well as the cryptosuite branch it's on top off.