### PR TITLE
Remove experimental cryptosuite term values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,18 @@
 
 ### Changed
 - **BREAKING**: Encode cryptosuite strings using a separate registry (specific
-  to cryptosuites) to further reduce their encoded size (instead of using
-  the global table). This approach is incompatible with previous encodings
-  that used the global table.
+  to cryptosuites) to further reduce their encoded size (instead of using the
+  global table). This approach is incompatible with previous encodings that
+  used the global table.
 - **BREAKING**: Encode all URIs using the vocab term codec. This allows
   arbitrary URIs to be encoded with the same small integers as other terms.
   The mapping in a context needs to use a redundant form: `{"URI":"URI"}`. This
   technique assume a use case where the CBOR-LD size has high priority over
   context size.
+
+### Removed
+- **BREAKING**: Remove and reserve cryptosuite values from term registry in
+  favor of the new cryptosuite codec.
 
 ## 6.0.3 - 2023-12-19
 

--- a/lib/codecs/registeredTermCodecs.js
+++ b/lib/codecs/registeredTermCodecs.js
@@ -12,6 +12,7 @@ export const CRYPTOSUITE_STRING_TO_ID = new Map();
 /**
  * @see https://digitalbazaar.github.io/cbor-ld-spec/#term-codec-registry
  */
+// 0x00 - 0x0F: reserved
 _addRegistration(0x10, 'https://www.w3.org/ns/activitystreams');
 _addRegistration(0x11, 'https://www.w3.org/2018/credentials/v1');
 _addRegistration(0x12, 'https://www.w3.org/ns/did/v1');
@@ -29,14 +30,20 @@ _addRegistration(0x1D, 'https://w3id.org/vaccination/v1');
 _addRegistration(0x1E, 'https://w3id.org/vc-revocation-list-2020/v1');
 _addRegistration(0x1F, 'https://w3id.org/dcc/v1');
 _addRegistration(0x20, 'https://w3id.org/vc/status-list/v1');
+// 0x21 - 0x2F: available
 _addRegistration(0x30, 'https://w3id.org/security/data-integrity/v1');
 _addRegistration(0x31, 'https://w3id.org/security/multikey/v1');
+// 0x32: reserved (in spec)
+// FIXME: Unclear on how to handle the openbadges URLs and versioning.
+// This value was never in the spec, but was added here, and potentially
+// elsewhere.
 _addRegistration(0x32, 'https://purl.imsglobal.org/spec/ob/v3p0/context.json');
 _addRegistration(0x33, 'https://w3id.org/security/data-integrity/v2');
-// these cryptosuite registrations are experimental and likely to be removed
-_addRegistration(0x34, 'ecdsa-rdfc-2019');
-_addRegistration(0x35, 'ecdsa-sd-2023');
-_addRegistration(0x36, 'eddsa-rdfc-2022');
+// 0x34 - 0x36: reserved
+// these cryptosuite registrations were experimental and are now reserved
+//_addRegistration(0x34, 'ecdsa-rdfc-2019');
+//_addRegistration(0x35, 'ecdsa-sd-2023');
+//_addRegistration(0x36, 'eddsa-rdfc-2022');
 
 // FIXME: add link to CBOR-LD spec for cryptosuite string sub-registry once
 // it is available


### PR DESCRIPTION
**BREAKING**: Remove and reserve cryptosuite values from term registry in favor of the new cryptosuite codec.