### PR TITLE
Add VCDM v2 context value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - **BREAKING**: Add support for compressing RFC 2397 data URLs. Base64 encoded
   data is compressed as binary.
+- Add VCDM v2 context value.
 
 ### Changed
 - **BREAKING**: Encode cryptosuite strings using a separate registry (specific

--- a/lib/codecs/registeredTermCodecs.js
+++ b/lib/codecs/registeredTermCodecs.js
@@ -30,7 +30,8 @@ _addRegistration(0x1D, 'https://w3id.org/vaccination/v1');
 _addRegistration(0x1E, 'https://w3id.org/vc-revocation-list-2020/v1');
 _addRegistration(0x1F, 'https://w3id.org/dcc/v1');
 _addRegistration(0x20, 'https://w3id.org/vc/status-list/v1');
-// 0x21 - 0x2F: available
+_addRegistration(0x21, 'https://www.w3.org/ns/credentials/v2');
+// 0x22 - 0x2F: available
 _addRegistration(0x30, 'https://w3id.org/security/data-integrity/v1');
 _addRegistration(0x31, 'https://w3id.org/security/multikey/v1');
 // 0x32: reserved (in spec)


### PR DESCRIPTION
Depends on addition to spec: https://github.com/json-ld/cbor-ld-spec/pull/27