### PR TITLE
Compute omitted `"@id"` value in term definitions when possible.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @digitalbazaar/cborld ChangeLog
 
+## 8.0.1 - 2025-05-dd
+
+### Fixed
+- Ensure omitted `"@id"` values in term definitions are resolved using the
+  term key if possible (for keys that are CURIEs or absolute URLs).
+
 ## 8.0.0 - 2025-04-24
 
 ### Changed

--- a/lib/ActiveContext.js
+++ b/lib/ActiveContext.js
@@ -163,7 +163,7 @@ function _resolveCuries({activeTermMap, context, newTermMap}) {
         activeTermMap, context, possibleCurie: id
       });
     } else {
-      // if `key` is a CURIE, then "@id" can be resolved to a value
+      // if `key` is a CURIE/absolute URL, then "@id" can be computed
       const resolved = _resolveCurie({
         activeTermMap, context, possibleCurie: key
       });

--- a/lib/ActiveContext.js
+++ b/lib/ActiveContext.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2021-2024 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2021-2025 Digital Bazaar, Inc. All rights reserved.
  */
 import {CborldError} from './CborldError.js';
 
@@ -155,18 +155,32 @@ function _resolveCurie({activeTermMap, context, possibleCurie}) {
 }
 
 function _resolveCuries({activeTermMap, context, newTermMap}) {
-  for(const def of newTermMap.values()) {
+  for(const [key, def] of newTermMap.entries()) {
     const id = def['@id'];
     const type = def['@type'];
     if(id !== undefined) {
       def['@id'] = _resolveCurie({
         activeTermMap, context, possibleCurie: id
       });
+    } else {
+      // if `key` is a CURIE, then "@id" can be resolved to a value
+      const resolved = _resolveCurie({
+        activeTermMap, context, possibleCurie: key
+      });
+      if(resolved.includes(':')) {
+        def['@id'] = resolved;
+      }
     }
     if(type !== undefined) {
       def['@type'] = _resolveCurie({
         activeTermMap, context, possibleCurie: type
       });
+    }
+    if(typeof def['@id'] !== 'string') {
+      throw new CborldError(
+        'ERR_INVALID_TERM_DEFINITION',
+        `Invalid JSON-LD term definition for "${key}"; the "@id" value ` +
+        'could not be determined.');
     }
   }
 }

--- a/lib/ContextLoader.js
+++ b/lib/ContextLoader.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2021-2024 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2021-2025 Digital Bazaar, Inc. All rights reserved.
  */
 import {FIRST_CUSTOM_TERM_ID, KEYWORDS_TABLE, reverseMap} from './tables.js';
 import {CborldError} from './CborldError.js';
@@ -114,11 +114,11 @@ export class ContextLoader {
       // normalize definition to an object
       if(typeof def === 'string') {
         def = {'@id': def};
-      } else if(!(typeof def === 'object' && typeof def['@id'] === 'string')) {
+      } else if(Object.prototype.toString.call(def) !== '[object Object]') {
         throw new CborldError(
           'ERR_INVALID_TERM_DEFINITION',
           `Invalid JSON-LD term definition for "${key}"; it must be ` +
-          'a string or an object with "@id".');
+          'a string or an object.');
       }
 
       // set term definition


### PR DESCRIPTION
Addresses #106.